### PR TITLE
Add support for load/unload worlds; add full list of features

### DIFF
--- a/include/q_simulation_interfaces/service_discovery.h
+++ b/include/q_simulation_interfaces/service_discovery.h
@@ -43,6 +43,10 @@ namespace q_simulation_interfaces
         SERVICE_STEP_SIMULATION,
         SERVICE_GET_SIM_STATE,
         SERVICE_SET_SIM_STATE,
+        SERVICE_GET_CURRENT_WORLD,
+        SERVICE_GET_AVAILABLE_WORLDS,
+        SERVICE_LOAD_WORLD,
+        SERVICE_UNLOAD_WORLD,
         ACTION_SIMULATE_STEPS,
         SUPPORTED_SERVICE_IDL_COUNT
     };
@@ -75,6 +79,12 @@ namespace q_simulation_interfaces
               false},
              {ServiceType::SERVICE_SET_SIM_STATE, "simulation_interfaces/srv/SetSimulationState", "Set Sim State",
               false},
+             {ServiceType::SERVICE_GET_CURRENT_WORLD, "simulation_interfaces/srv/GetCurrentWorld", "Get Current World",
+              false},
+             {ServiceType::SERVICE_GET_AVAILABLE_WORLDS, "simulation_interfaces/srv/GetAvailableWorlds",
+              "Get Available Worlds", false},
+             {ServiceType::SERVICE_LOAD_WORLD, "simulation_interfaces/srv/LoadWorld", "Load World", false},
+             {ServiceType::SERVICE_UNLOAD_WORLD, "simulation_interfaces/srv/UnloadWorld", "Unload World", false},
              {ServiceType::ACTION_SIMULATE_STEPS, "simulation_interfaces/action/SimulateSteps", "Simulate Steps",
               true}}};
 

--- a/src/sim_widget.ui
+++ b/src/sim_widget.ui
@@ -532,6 +532,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="worldsUseOfflineCheck">
+         <property name="text">
+          <string>Worlds: Offline only</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QComboBox" name="availableWorldsCombo"/>
        </item>
        <item>

--- a/src/sim_widget.ui
+++ b/src/sim_widget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <layout class="QFormLayout" name="formLayout">
-   <item row="0" column="0">
+   <item row="0" column="1">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -518,6 +518,67 @@
         </widget>
        </item>
       </layout>
+     </widget>
+     <widget class="QWidget" name="worlds">
+      <attribute name="title">
+       <string>Worlds</string>
+      </attribute>
+      <widget class="QWidget" name="verticalLayoutWidget">
+       <property name="geometry">
+        <rect>
+         <x>-1</x>
+         <y>-1</y>
+         <width>681</width>
+         <height>401</height>
+        </rect>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <widget class="QPushButton" name="getAvailableWorldsButton">
+          <property name="text">
+           <string>Get Available Worlds</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="availableWorldsCombo"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="loadWorldButton">
+          <property name="text">
+           <string>Load World</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="unloadWorldButton">
+          <property name="text">
+           <string>Unload World</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="currentWorldLabel">
+          <property name="text">
+           <string>Current world:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
      </widget>
      <widget class="QWidget" name="servicesNames">
       <property name="enabled">

--- a/src/sim_widget.ui
+++ b/src/sim_widget.ui
@@ -14,7 +14,7 @@
    <item row="0" column="1">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="simulation">
       <attribute name="title">
@@ -523,62 +523,52 @@
       <attribute name="title">
        <string>Worlds</string>
       </attribute>
-      <widget class="QWidget" name="verticalLayoutWidget">
-       <property name="geometry">
-        <rect>
-         <x>-1</x>
-         <y>-1</y>
-         <width>681</width>
-         <height>401</height>
-        </rect>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_4">
-        <item>
-         <widget class="QPushButton" name="getAvailableWorldsButton">
-          <property name="text">
-           <string>Get Available Worlds</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="availableWorldsCombo"/>
-        </item>
-        <item>
-         <widget class="QPushButton" name="loadWorldButton">
-          <property name="text">
-           <string>Load World</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="unloadWorldButton">
-          <property name="text">
-           <string>Unload World</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="currentWorldLabel">
-          <property name="text">
-           <string>Current world:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </widget>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QPushButton" name="getAvailableWorldsButton">
+         <property name="text">
+          <string>Get Available Worlds</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="availableWorldsCombo"/>
+       </item>
+       <item>
+        <widget class="QPushButton" name="loadWorldButton">
+         <property name="text">
+          <string>Load World</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="unloadWorldButton">
+         <property name="text">
+          <string>Unload World</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="currentWorldLabel">
+         <property name="text">
+          <string>Current world:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>225</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="servicesNames">
       <property name="enabled">

--- a/src/sim_widget.ui
+++ b/src/sim_widget.ui
@@ -14,7 +14,7 @@
    <item row="0" column="1">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>3</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="simulation">
       <attribute name="title">

--- a/src/simulation_widget.cpp
+++ b/src/simulation_widget.cpp
@@ -249,9 +249,14 @@ namespace q_simulation_interfaces
 
         simulation_interfaces::srv::LoadWorld::Request request;
         auto selectedWorld = ui_->availableWorldsCombo->currentText();
-        request.uri = selectedWorld.toStdString();
-
-        std::cout << "Loading world: " << request.uri << std::endl;
+        if (useUriForWorlds_)
+        {
+            request.uri = selectedWorld.toStdString();
+        }
+        else
+        {
+            request.resource_string = selectedWorld.toStdString();
+        }
 
         auto cb = [this](auto response)
         {
@@ -297,7 +302,7 @@ namespace q_simulation_interfaces
         }
 
         simulation_interfaces::srv::GetAvailableWorlds::Request request;
-        request.offline_only = true;
+        request.offline_only = ui_->worldsUseOfflineCheck->isChecked();
 
         auto cb = [this](auto response)
         {
@@ -307,9 +312,20 @@ namespace q_simulation_interfaces
                 ui_->availableWorldsCombo->clear();
 
                 auto worlds = response->worlds;
+
+                if (!worlds.empty())
+                {
+                    // Determine if we are using URI or resource string based on the first world
+                    useUriForWorlds_ = !worlds[0].world_resource.uri.empty();
+                }
+
                 for (const auto& world : worlds)
                 {
-                    ui_->availableWorldsCombo->addItem(QString::fromStdString(world.world_resource.uri));
+
+                    const QString worldStr = useUriForWorlds_
+                        ? QString::fromStdString(world.world_resource.uri)
+                        : QString::fromStdString(world.world_resource.resource_string);
+                    ui_->availableWorldsCombo->addItem(worldStr);
                 }
             }
         };
@@ -328,8 +344,11 @@ namespace q_simulation_interfaces
             ProduceWarningIfProblem(this, "Get Current World", response);
             if (response && response->result.result == simulation_interfaces::msg::Result::RESULT_OK)
             {
-                ui_->currentWorldLabel->setText("Current world: " +
-                                                QString::fromStdString(response->world.world_resource.uri));
+                useUriForWorlds_ = !response->world.world_resource.uri.empty();
+                const QString worldStr = useUriForWorlds_
+                    ? QString::fromStdString(response->world.world_resource.uri)
+                    : QString::fromStdString(response->world.world_resource.resource_string);
+                ui_->currentWorldLabel->setText("Current world: " + worldStr);
             }
         };
         getCurrentWorldService_->call_service_async(cb, request);

--- a/src/simulation_widget.cpp
+++ b/src/simulation_widget.cpp
@@ -261,11 +261,7 @@ namespace q_simulation_interfaces
         auto cb = [this](auto response)
         {
             ProduceWarningIfProblem(this, "Load World", response);
-            if (response)
-            {
-                ui_->currentWorldLabel->setText("Current world: " +
-                                                QString::fromStdString(response->world.world_resource.uri));
-            }
+            GetCurrentWorld();
         };
         loadWorldService_->call_service_async(cb, request);
     }
@@ -284,10 +280,7 @@ namespace q_simulation_interfaces
         auto cb = [this](auto response)
         {
             ProduceWarningIfProblem(this, "Unload World", response);
-            if (response)
-            {
-                ui_->currentWorldLabel->setText("Current world: ");
-            }
+            GetCurrentWorld();
         };
         unloadWorldService_->call_service_async(cb, request);
     }
@@ -336,11 +329,21 @@ namespace q_simulation_interfaces
     {
         if (!getCurrentWorldService_)
         {
+            // Getting current world is called periodically, so just update the label without showing a message box
+            ui_->currentWorldLabel->setText("Current world: unknown due to unavailable service");
             return;
         }
         simulation_interfaces::srv::GetCurrentWorld::Request request;
         auto cb = [this](auto response)
         {
+            // Check for NO_WORLD_LOADED error, which is not an error in this context
+            if (response &&
+                response->result.result == simulation_interfaces::srv::GetCurrentWorld::Response::NO_WORLD_LOADED)
+            {
+                ui_->currentWorldLabel->setText("Current world: No world loaded");
+                return;
+            }
+
             ProduceWarningIfProblem(this, "Get Current World", response);
             if (response && response->result.result == simulation_interfaces::msg::Result::RESULT_OK)
             {

--- a/src/simulation_widget.cpp
+++ b/src/simulation_widget.cpp
@@ -114,6 +114,9 @@ namespace q_simulation_interfaces
         connect(ui_->setSimStateButton, &QPushButton::clicked, this, &SimulationWidget::SetSimulationState);
         connect(ui_->stepSimServiceButton, &QPushButton::clicked, this, &SimulationWidget::StepSimulationService);
         connect(ui_->ComboEntities, &QComboBox::currentTextChanged, this, [this]() { this->GetEntityState(true); });
+        connect(ui_->getAvailableWorldsButton, &QPushButton::clicked, this, &SimulationWidget::GetAvailableWorlds);
+        connect(ui_->loadWorldButton, &QPushButton::clicked, this, &SimulationWidget::LoadWorld);
+        connect(ui_->unloadWorldButton, &QPushButton::clicked, this, &SimulationWidget::UnloadWorld);
 
         // Connect spawn position spin boxes to update marker
         connect(ui_->doubleSpinBoxX, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
@@ -232,6 +235,97 @@ namespace q_simulation_interfaces
             }
         };
         setSimulationStateService_->call_service_async(cb, request);
+    }
+
+
+    void SimulationWidget::LoadWorld()
+    {
+        if (!loadWorldService_)
+        {
+            QMessageBox::warning(this, "Service Not Available",
+                                 "Load World service is not available. Please select a valid service.");
+            return;
+        }
+
+        simulation_interfaces::srv::LoadWorld::Request request;
+        auto selectedWorld = ui_->availableWorldsCombo->currentText();
+        request.uri = selectedWorld.toStdString();
+
+        auto cb = [this](auto response)
+        {
+            ProduceWarningIfProblem(this, "Load World", response);
+            if (response)
+            {
+                ui_->currentWorldLabel->setText("Current world: " + QString::fromStdString(response->world));
+            }
+        };
+    }
+
+    void SimulationWidget::UnloadWorld()
+    {
+        if (!unloadWorldService_)
+        {
+            QMessageBox::warning(this, "Service Not Available",
+                                 "Unload World service is not available. Please select a valid service.");
+            return;
+        }
+
+        simulation_interfaces::srv::UnloadWorld::Request request;
+
+        auto cb = [this](auto response)
+        {
+            ProduceWarningIfProblem(this, "Unload World", response);
+            if (response)
+            {
+                ui_->currentWorldLabel->setText("Current world: ");
+            }
+        };
+        unloadWorldService_->call_service_async(cb, request);
+    }
+
+    void SimulationWidget::GetAvailableWorlds()
+    {
+        if (!getAvailableWorldsService_)
+        {
+            QMessageBox::warning(this, "Service Not Available",
+                                 "Get Available Worlds service is not available. Please select a valid service.");
+            return;
+        }
+
+        simulation_interfaces::srv::GetAvailableWorlds::Request request;
+        auto cb = [this](auto response)
+        {
+            ProduceWarningIfProblem(this, "Get Available Worlds", response);
+            if (response && response->result.result == simulation_interfaces::msg::Result::RESULT_OK)
+            {
+                ui_->availableWorldsCombo->clear();
+
+                auto worlds = response->worlds;
+                for (const auto& world : worlds)
+                {
+                    ui_->availableWorldsCombo->addItem(QString::fromStdString(world.name));
+                }
+            }
+        };
+        getAvailableWorldsService_->call_service_async(cb, request);
+    }
+
+    void SimulationWidget::GetCurrentWorld()
+    {
+        if (!getCurrentWorldService_)
+        {
+            return;
+        }
+        simulation_interfaces::srv::GetCurrentWorld::Request request;
+        auto cb = [this](auto response)
+        {
+            ProduceWarningIfProblem(this, "Get Current World", response);
+            if (response && response->result.result == simulation_interfaces::msg::Result::RESULT_OK)
+            {
+                ui_->currentWorldLabel->setText("Current world: " + QString::fromStdString(response->world.name));
+            }
+        };
+        getCurrentWorldService_->call_service_async(cb, request);
     }
 
     void SimulationWidget::ActionThreadWorker(int steps)

--- a/src/simulation_widget.cpp
+++ b/src/simulation_widget.cpp
@@ -251,14 +251,18 @@ namespace q_simulation_interfaces
         auto selectedWorld = ui_->availableWorldsCombo->currentText();
         request.uri = selectedWorld.toStdString();
 
+        std::cout << "Loading world: " << request.uri << std::endl;
+
         auto cb = [this](auto response)
         {
             ProduceWarningIfProblem(this, "Load World", response);
             if (response)
             {
-                ui_->currentWorldLabel->setText("Current world: " + QString::fromStdString(response->world));
+                ui_->currentWorldLabel->setText("Current world: " +
+                                                QString::fromStdString(response->world.world_resource.uri));
             }
         };
+        loadWorldService_->call_service_async(cb, request);
     }
 
     void SimulationWidget::UnloadWorld()
@@ -293,6 +297,8 @@ namespace q_simulation_interfaces
         }
 
         simulation_interfaces::srv::GetAvailableWorlds::Request request;
+        request.offline_only = true;
+
         auto cb = [this](auto response)
         {
             ProduceWarningIfProblem(this, "Get Available Worlds", response);
@@ -303,7 +309,7 @@ namespace q_simulation_interfaces
                 auto worlds = response->worlds;
                 for (const auto& world : worlds)
                 {
-                    ui_->availableWorldsCombo->addItem(QString::fromStdString(world.name));
+                    ui_->availableWorldsCombo->addItem(QString::fromStdString(world.world_resource.uri));
                 }
             }
         };
@@ -322,7 +328,8 @@ namespace q_simulation_interfaces
             ProduceWarningIfProblem(this, "Get Current World", response);
             if (response && response->result.result == simulation_interfaces::msg::Result::RESULT_OK)
             {
-                ui_->currentWorldLabel->setText("Current world: " + QString::fromStdString(response->world.name));
+                ui_->currentWorldLabel->setText("Current world: " +
+                                                QString::fromStdString(response->world.world_resource.uri));
             }
         };
         getCurrentWorldService_->call_service_async(cb, request);
@@ -969,6 +976,47 @@ namespace q_simulation_interfaces
             if (setSimulationStateService_)
             {
                 serviceInterfaces_.insert(setSimulationStateService_);
+            }
+            break;
+        case ServiceType::SERVICE_GET_CURRENT_WORLD:
+            serviceInterfaces_.erase(getCurrentWorldService_);
+            getCurrentWorldService_ = shouldReset
+                ? nullptr
+                : std::make_shared<Service<simulation_interfaces::srv::GetCurrentWorld>>(selectedServiceName, node_);
+            if (getCurrentWorldService_)
+            {
+                serviceInterfaces_.insert(getCurrentWorldService_);
+            }
+            GetCurrentWorld();
+            break;
+        case ServiceType::SERVICE_GET_AVAILABLE_WORLDS:
+            serviceInterfaces_.erase(getAvailableWorldsService_);
+            getAvailableWorldsService_ = shouldReset
+                ? nullptr
+                : std::make_shared<Service<simulation_interfaces::srv::GetAvailableWorlds>>(selectedServiceName, node_);
+            if (getAvailableWorldsService_)
+            {
+                serviceInterfaces_.insert(getAvailableWorldsService_);
+            }
+            break;
+        case ServiceType::SERVICE_LOAD_WORLD:
+            serviceInterfaces_.erase(loadWorldService_);
+            loadWorldService_ = shouldReset
+                ? nullptr
+                : std::make_shared<Service<simulation_interfaces::srv::LoadWorld>>(selectedServiceName, node_);
+            if (loadWorldService_)
+            {
+                serviceInterfaces_.insert(loadWorldService_);
+            }
+            break;
+        case ServiceType::SERVICE_UNLOAD_WORLD:
+            serviceInterfaces_.erase(unloadWorldService_);
+            unloadWorldService_ = shouldReset
+                ? nullptr
+                : std::make_shared<Service<simulation_interfaces::srv::UnloadWorld>>(selectedServiceName, node_);
+            if (unloadWorldService_)
+            {
+                serviceInterfaces_.insert(unloadWorldService_);
             }
             break;
         case ServiceType::ACTION_SIMULATE_STEPS:

--- a/src/simulation_widget.h
+++ b/src/simulation_widget.h
@@ -127,6 +127,9 @@ namespace q_simulation_interfaces
         // Action names
         std::string simulateStepsAction_ = "";
 
+        // Whether to use URI or resource string for worlds
+        bool useUriForWorlds_ = true;
+
         // Vector to hold all service interfaces of created services
         std::set<std::shared_ptr<ServiceInterface>> serviceInterfaces_;
         QTimer* timer_; //! Timer for periodic updates

--- a/src/simulation_widget.h
+++ b/src/simulation_widget.h
@@ -30,15 +30,19 @@
 #include <QComboBox>
 #include <q_simulation_interfaces/service_discovery.h>
 #include <simulation_interfaces/srv/delete_entity.hpp>
+#include <simulation_interfaces/srv/get_available_worlds.hpp>
+#include <simulation_interfaces/srv/get_current_world.hpp>
 #include <simulation_interfaces/srv/get_entities.hpp>
 #include <simulation_interfaces/srv/get_entity_state.hpp>
 #include <simulation_interfaces/srv/get_simulation_state.hpp>
 #include <simulation_interfaces/srv/get_spawnables.hpp>
+#include <simulation_interfaces/srv/load_world.hpp>
 #include <simulation_interfaces/srv/reset_simulation.hpp>
 #include <simulation_interfaces/srv/set_entity_state.hpp>
 #include <simulation_interfaces/srv/set_simulation_state.hpp>
 #include <simulation_interfaces/srv/spawn_entity.hpp>
 #include <simulation_interfaces/srv/step_simulation.hpp>
+#include <simulation_interfaces/srv/unload_world.hpp>
 
 namespace Ui
 {
@@ -65,7 +69,6 @@ namespace q_simulation_interfaces
         void hideEvent(QHideEvent* event) override;
         void showEvent(QShowEvent* event) override;
 
-        void onShowServicesTab();
         void GetSpawnables();
         void SpawnButton();
         void GetAllEntities();
@@ -78,6 +81,10 @@ namespace q_simulation_interfaces
         void GetSimulationState();
         void SetSimulationState();
         void StepSimulationService();
+        void LoadWorld();
+        void UnloadWorld();
+        void GetAvailableWorlds();
+        void GetCurrentWorld();
 
         //! The thread with own ROS 2 node that will run the action client
         void ActionThreadWorker(int steps);
@@ -112,6 +119,10 @@ namespace q_simulation_interfaces
         std::shared_ptr<Service<simulation_interfaces::srv::GetSimulationState>> getSimulationStateService_;
         std::shared_ptr<Service<simulation_interfaces::srv::SetSimulationState>> setSimulationStateService_;
         std::shared_ptr<Service<simulation_interfaces::srv::StepSimulation>> stepSimulationService_;
+        std::shared_ptr<Service<simulation_interfaces::srv::GetAvailableWorlds>> getAvailableWorldsService_;
+        std::shared_ptr<Service<simulation_interfaces::srv::GetCurrentWorld>> getCurrentWorldService_;
+        std::shared_ptr<Service<simulation_interfaces::srv::LoadWorld>> loadWorldService_;
+        std::shared_ptr<Service<simulation_interfaces::srv::UnloadWorld>> unloadWorldService_;
 
         // Action names
         std::string simulateStepsAction_ = "";

--- a/src/string_to_keys.h
+++ b/src/string_to_keys.h
@@ -44,7 +44,14 @@ const std::map<int, std::string> FeatureToName{
     {31, "STEP_SIMULATION_SINGLE"},
     {32, "STEP_SIMULATION_MULTIPLE"},
     {33, "STEP_SIMULATION_ACTION"},
+    {40, "WORLD_LOADING"},
+    {41, "WORLD_RESOURCE_STRING"},
+    {42, "WORLD_TAGS"},
+    {43, "WORLD_UNLOADING"},
+    {44, "WORLD_INFO_GETTING"},
+    {45, "AVAILABLE_WORLDS"},
 };
+
 const std::map<int, std::string> FeatureDescription{
     {0, "Supports spawn interface (SpawnEntity)."},
     {1, "Supports deleting entities (DeleteEntity)."},
@@ -71,7 +78,14 @@ const std::map<int, std::string> FeatureDescription{
     {31, "Supports single stepping through simulation with StepSimulation interface."},
     {32, "Supports multi-stepping through simulation, either through StepSimulation service or StepSimulation action."},
     {33, "Supports SimulateSteps action interface."},
+    {40, "Supports loading worlds through LoadWorld interface."},
+    {41, "Supports resource_string field in LoadWorld interface."},
+    {42, "Supports tags field in LoadWorld interface."},
+    {43, "Supports unloading worlds through UnloadWorld interface."},
+    {44, "Supports GetWorldInfo interface."},
+    {45, "Supports GetAvailableWorlds interface."},
 };
+
 const std::unordered_map<std::string, int> ScopeNameToId{
     {"SCOPE_DEFAULT", 0}, {"SCOPE_TIME", 1}, {"SCOPE_STATE", 2}, {"SCOPE_SPAWNED", 4}, {"SCOPE_ALL", 255},
 };


### PR DESCRIPTION
- add support for worlds in q_simulation_interfaces
- add all missing features to the list, so it can parse the output from simulator

<img width="817" height="655" alt="image" src="https://github.com/user-attachments/assets/9b5e20de-ff7b-4efd-8d04-a0ae146543de" />
